### PR TITLE
Handle change in field from singular string to repeated

### DIFF
--- a/app.go
+++ b/app.go
@@ -37,11 +37,26 @@ func main() {
 	httpClient := http.Client{}
 	clock := clockwork.NewRealClock()
 	apiHost, _ := url.Parse("https://waste-api-hackney-live.ieg4.net/f806d91c-e133-43a6-ba9a-c0ae4f4cccf6")
-	binsClient := client.BinsClient{httpClient, clock, apiHost, cache}
+	binsClient := client.BinsClient{
+		HttpClient: httpClient,
+		Clock:      clock,
+		ApiHost:    apiHost,
+		Cache:      cache,
+	}
 
-	collectionHandler := handler.CollectionHandler{binsClient, cache}
-	addressHandler := handler.AddressHandler{binsClient, cache}
-	readmeHandler := handler.MarkdownHandler{readme, "Hackney Bindicator", "static/style.css"}
+	collectionHandler := handler.CollectionHandler{
+		Client: binsClient,
+		Cache:  cache,
+	}
+	addressHandler := handler.AddressHandler{
+		Client: binsClient,
+		Cache:  cache,
+	}
+	readmeHandler := handler.MarkdownHandler{
+		Markdown: readme,
+		Title:    "Hackney Bindicator",
+		CssPath:  "static/style.css",
+	}
 
 	r := mux.NewRouter()
 	r.HandleFunc("/property/{property_id}", collectionHandler.Handle)

--- a/client/workflow_id.go
+++ b/client/workflow_id.go
@@ -37,18 +37,21 @@ func (c BinsClient) GetBinWorkflowId(binId string) (string, error) {
 	}
 
 	type result struct {
-		ID string `json:"scheduleCodeWorkflowID"`
+		IDs []string `json:"scheduleCodeWorkflowIDs"`
 	}
 
 	var data result
 	json.Unmarshal(respBody, &data)
 
-	if data.ID == "" {
+	if len(data.IDs) == 0 {
+		return "", errors.New("Workflow IDs not found")
+	}
+	if data.IDs[0] == "" {
 		return "", errors.New("Workflow ID not found")
 	}
 
 	if c.Cache != nil {
-		c.Cache.Add(target, data.ID)
+		c.Cache.Add(target, data.IDs[0])
 	}
-	return data.ID, nil
+	return data.IDs[0], nil
 }

--- a/client/workflow_id_test.go
+++ b/client/workflow_id_test.go
@@ -112,14 +112,32 @@ func TestWorkflowIdNotFound(t *testing.T) {
 	res, err := client.GetBinWorkflowId(BinId)
 
 	assert.Empty(t, res)
-	assert.Contains(t, err.Error(), "Workflow ID not found")
+	assert.Contains(t, err.Error(), "Workflow IDs not found")
 }
 
-func TestEmptyWorkflowIdFound(t *testing.T) {
+func TestEmptyWorkflowIdList(t *testing.T) {
 	apiSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `
 			{
-				"scheduleCodeWorkflowID": ""
+				"scheduleCodeWorkflowIDs": []
+			}
+		`)
+	}))
+	defer apiSvr.Close()
+	apiUrl, _ := url.Parse(apiSvr.URL)
+	client := client.BinsClient{http.Client{}, nil, apiUrl, nil}
+
+	res, err := client.GetBinWorkflowId(BinId)
+
+	assert.Empty(t, res)
+	assert.Contains(t, err.Error(), "Workflow IDs not found")
+}
+
+func TestEmptyFirstWorkflowId(t *testing.T) {
+	apiSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+			{
+				"scheduleCodeWorkflowIDs": [""]
 			}
 		`)
 	}))
@@ -137,7 +155,7 @@ func TestSuccessWorkflowId(t *testing.T) {
 	apiSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `
 			{
-				"scheduleCodeWorkflowID": "foo"
+				"scheduleCodeWorkflowIDs": ["foo"]
 			}
 		`)
 	}))
@@ -156,7 +174,7 @@ func TestFetchWorkflowIdTwiceWithoutCache(t *testing.T) {
 	apiSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `
 			{
-				"scheduleCodeWorkflowID": "foo"
+				"scheduleCodeWorkflowIDs": ["foo"]
 			}
 		`)
 		fetches += 1
@@ -176,7 +194,7 @@ func TestFetchWorkflowIdOnceWithCache(t *testing.T) {
 	apiSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `
 			{
-				"scheduleCodeWorkflowID": "foo"
+				"scheduleCodeWorkflowIDs": ["foo"]
 			}
 		`)
 		fetches += 1

--- a/handler/collection_test.go
+++ b/handler/collection_test.go
@@ -49,13 +49,13 @@ const Bin2TypeJsonResponse = `
 const WorkflowId1 = "workflow1"
 const Bin1WorkflowIdJsonResponse = `
 	{
-		"scheduleCodeWorkflowID": "` + WorkflowId1 + `"
+		"scheduleCodeWorkflowIDs": ["` + WorkflowId1 + `"]
 	}
 `
 const WorkflowId2 = "workflow2"
 const Bin2WorkflowIdJsonResponse = `
 	{
-		"scheduleCodeWorkflowID": "` + WorkflowId2 + `"
+		"scheduleCodeWorkflowIDs": ["` + WorkflowId2 + `"]
 	}
 `
 const Workflow1ScheduleJsonResponse = `


### PR DESCRIPTION
Breaking change in the upstream API we're wrapping. The string field `scheduleCodeWorkflowID` in the workflow ID response has been replaced with a list of strings called `scheduleCodeWorkflowIDs`. For now only seen instances with one value so making the simplifying assumption that we can just use the first entry.