### PR TITLE
Make deployable again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+ARG GO_VERSION=1
+FROM golang:${GO_VERSION}-bookworm AS builder
+
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app/
+
+RUN go build -o hackney-bindicator app.go
+
+FROM debian:bookworm
+
+WORKDIR /
+
+COPY --from=builder /usr/src/app/hackney-bindicator /app/
+COPY --from=builder /usr/src/app/README.md /app/
+COPY --from=builder /usr/src/app/static /app/static/
+
+CMD [ "/app/hackney-bindicator" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,12 @@ FROM debian:bookworm
 
 WORKDIR /
 
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /usr/src/app/hackney-bindicator /app/
-COPY --from=builder /usr/src/app/README.md /app/
-COPY --from=builder /usr/src/app/static /app/static/
+EXPOSE 8080
 
 CMD [ "/app/hackney-bindicator" ]

--- a/app.go
+++ b/app.go
@@ -64,7 +64,7 @@ func main() {
 	r.PathPrefix("/static/").Handler(http.FileServer(http.FS(static)))
 	r.HandleFunc("/readme", readmeHandler.Handle)
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "static/index.html")
+    	http.ServeFileFS(w, r, static, "static/index.html")
 	})
 
 	log.Println("listening on", port)

--- a/fly.toml
+++ b/fly.toml
@@ -7,8 +7,10 @@ app = "hackney-bindicator"
 primary_region = "lhr"
 
 [build]
-  builder = "paketobuildpacks/builder:base"
-  buildpacks = ["gcr.io/paketo-buildpacks/go"]
+dockerfile = './Dockerfile'
+
+[build.args]
+GO_VERSION = '1.24'
 
 [env]
   PORT = "8080"


### PR DESCRIPTION
- Fly's old way of building seems to be deprecated and no longer working
- So use docker container
- And ensure that it works, with certificates for https calls and serving the index page from the embedded static folder