### PR TITLE
Make assignees an array

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     groups:
       go:
         patterns: ["*"]
-    assignees: "dinosaursrarr"
+    assignees: ["dinosaursrarr"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -19,4 +19,4 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
-    assignees: "dinosaursrarr"
+    assignees: ["dinosaursrarr"]


### PR DESCRIPTION
For the love of christ, you'd think they could check this at the PR stage instead of immediately after merging.